### PR TITLE
Prepares repository for parallel worktree development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ node_modules/
 # Eslint cache
 .eslintcache
 
+# Git worktrees
+.worktrees/
+
 # MacOS system files
 .DS_Store
 


### PR DESCRIPTION
TL;DR
-----

Adds `.worktrees/` to `.gitignore` so git worktrees can be used for parallel development without polluting the repository.

Details
-------

Sets up for work on the event-driven bidirectional sync (#6), which has several issues that can be worked in parallel. Keeps worktree directories under the project root in `.worktrees/` as a local convention, and excludes them from version control so worktree artifacts don't accidentally get committed.