### PR TITLE
Add SyncGuard for loop prevention and configure Salesforce Site

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,37 @@ included in the fulfillment email.
    emails.
 8. Test the integration by creating and closing an Opportunity, then activating the resulting Contract and Order.
 
+## Salesforce Site Setup
+
+A Salesforce Site is required to expose the webhook endpoint publicly so
+Replicated can POST event notifications to Salesforce. HMAC-SHA256 signature
+verification in the Apex code handles security.
+
+### Steps
+
+1. Navigate to **Setup → Sites** and create a new Site.
+2. Set the Site URL suffix (e.g., `replicated-webhooks`).
+3. Grant the Site Guest User profile access to:
+   - `ReplicatedWebhookReceiver` Apex class
+   - Publish access on `Replicated_Webhook__e` Platform Event
+4. Activate the Site.
+
+The resulting webhook URL will be:
+
+```
+https://<org-domain>.my.salesforce-sites.com/services/apexrest/replicated/webhook
+```
+
+Configure this URL in the Replicated Vendor Portal under **Notifications →
+Create Notification**:
+
+1. Select the relevant event types (e.g., customer.created, instance.created,
+   license expiring).
+2. Set the webhook URL to the Salesforce Site URL above.
+3. Configure the HMAC signing secret (must match the value stored in the
+   `Replicated_Webhook_Secret__mdt` custom metadata record in Salesforce).
+4. Optionally add custom headers for additional authentication.
+
 ## Usage
 
 The provided Makefile includes several useful commands:

--- a/create-license/main/default/classes/SyncGuard.cls
+++ b/create-license/main/default/classes/SyncGuard.cls
@@ -1,0 +1,9 @@
+public class SyncGuard {
+    // Records currently being updated by inbound webhook processing.
+    // Outbound triggers check this set and skip records present here.
+    public static Set<Id> inboundSyncIds = new Set<Id>();
+
+    // Records already sent outbound in this transaction.
+    // Prevents duplicate outbound callouts for the same record.
+    public static Set<Id> outboundSyncIds = new Set<Id>();
+}

--- a/create-license/main/default/classes/SyncGuard.cls-meta.xml
+++ b/create-license/main/default/classes/SyncGuard.cls-meta.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>


### PR DESCRIPTION
TL;DR
-----

Adds the SyncGuard utility class for loop prevention and documents the Salesforce Site setup for webhooks.

Details
-------

### SyncGuard

Prevents looping when an inbound webhook updates an account which might otherwise trigger a CDC even that would call Replicted and fire anither webhook. Breaks the cycle with two static `Set<Id>` fields: inbound handlers add record IDs before DML, and outbound triggers check the set and skip records that are already there. The static sets are transaction-scoped, so they only prevent same-transaction loops. The `Last_Synced_By__c` field on Account (#7) handles the cross-transaction case.

The README now includes setup steps for exposing the webhook endpoint via a Salesforce Site. Replicated POSTs webhooks to a URL — it can't do Salesforce OAuth — so a Site provides the public URL. HMAC verification in the Apex code handles security.

The referenced components (`ReplicatedWebhookReceiver`, `Replicated_Webhook__e`, `Replicated_Webhook_Secret__mdt`) ship in #7 and #10. Don't activate the Site until those land.

Closes #9
Part of #6
