### PR TITLE
Adds project conventions file

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# Replicated Salesforce Fulfillment
+
+Salesforce DX project that integrates the Replicated Platform with Salesforce for automated license fulfillment and bidirectional event sync.
+
+## Project Structure
+
+- `create-license/main/default/` — Salesforce source (classes, triggers, objects, layouts, profiles)
+- `data/` — Sample data for import
+- `hack/` — Utility scripts
+- `docs/` — Research documents and user stories
+
+## Development
+
+### Prerequisites
+
+- Salesforce CLI (`sf`)
+- Access to Salesforce org: `shortriblabs-dev-ed.develop.my.salesforce.com`
+- Replicated Vendor Portal API token
+
+### Common Commands
+
+```bash
+make deploy      # Deploy to Salesforce org
+make retrieve    # Retrieve latest metadata from org
+make credentials # Set Replicated API token
+make import      # Import sample data
+make clean       # Clean up org data (use with caution)
+```
+
+### Salesforce API Version
+
+All metadata uses API version **61.0**.
+
+## Conventions
+
+### Branch Naming
+
+`{type}/{author}/{verb-phrase-description}`
+
+- Types: `feature`, `chore`, `docs`, `fix`
+- Author: `crdant` (Chuck), `claude` (Claude)
+- Examples: `feature/claude/adds-sync-guard`, `chore/claude/prepares-claude-md`
+
+### Apex Class Metadata
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>61.0</apiVersion>
+    <status>Active</status>
+</ApexClass>
+```
+
+### Key Design Patterns
+
+- **Queueable for callouts**: All Replicated API calls go through Queueable classes (e.g., `ReplicatedFulfillment`) because Salesforce triggers can't make HTTP callouts directly.
+- **Platform Events for webhooks**: Inbound webhooks publish `Replicated_Webhook__e` Platform Events for async processing (decouples receipt from handling).
+- **SyncGuard for loop prevention**: Static sets (`SyncGuard.inboundSyncIds`) prevent infinite loops in bidirectional sync.
+- **`custom_id` as reconciliation key**: Replicated customer `custom_id` = Salesforce Account ID. This is the bidirectional join key.
+
+### Key Salesforce Objects
+
+- `Product2` — Custom fields map to Replicated app/channel/entitlements
+- `Order.LicenseId__c` — Stores generated Replicated license ID
+- `Replicated_Instance__c` — Tracks Replicated instances (read-only in SF)
+- `Replicated_Webhook__e` — Platform Event for inbound webhook processing
+- `ReplicatedVendorPortalCredential__mdt` — API token storage
+- `Replicated_Webhook_Secret__mdt` — HMAC signing secret storage


### PR DESCRIPTION
TL;DR
-----

Adds a conventions file so Claude Code has project context from the start

Details
-------

Every time a new session starts, there's a ramp-up period where Claude has to rediscover the project structure, the branch naming rules, and why the code is structured the way it is. This file short-circuits all of that.

Vovers the practical stuff -- `make deploy`, `make retrieve`, the API version is 61.0, branches follow `{type}/{author}/{verb-phrase}` -- but also the architectural reasoning that shapes every change. Things like why
all Replicated API calls go through Queueable classes, why Platform Events decouple webhook receipt from processing, how SyncGuard prevents infinite loops, and why `custom_id` is the join key between the two systems.