### PR TITLE
Evaluate secure secret storage for CMT credentials

### DIFF
--- a/docs/research/2026-03-16-secret-storage-evaluation.md
+++ b/docs/research/2026-03-16-secret-storage-evaluation.md
@@ -1,0 +1,220 @@
+---
+date: 2026-03-16
+researcher: Claude
+branch: docs/claude/evaluates-secret-storage
+repository: crdant/cold-leads-to-hot-signal
+topic: "Evaluate secure secret storage for Custom Metadata Type credentials"
+tags: [research, salesforce, security, named-credentials, custom-metadata-type, secrets-management]
+status: complete
+last_updated: 2026-03-16
+last_updated_by: Claude
+last_updated_note: "Evaluation complete — Named Credentials recommended for API token, Protected CMT acceptable for HMAC secret"
+---
+
+# Evaluation: Secure Secret Storage for Custom Metadata Type Credentials
+
+**Date**: 2026-03-16
+**Researcher**: Claude
+**Branch**: docs/claude/evaluates-secret-storage
+**Repository**: crdant/cold-leads-to-hot-signal
+
+## Research Question
+
+The project stores two sensitive credentials as plaintext Text fields in Protected Custom Metadata Types. What is the most appropriate storage mechanism given the security trade-offs and the Developer Edition org context?
+
+## Current State
+
+| Credential | Object | Field | Type | Visibility | Used By |
+|---|---|---|---|---|---|
+| Replicated Vendor Portal API token | `Replicated_Vendor_Portal_API_Credential__mdt` | `ApiToken__c` | Text(100) | Protected | `ReplicatedFulfillment` → `ReplicatedPlatform` (Authorization header on all HTTP callouts) |
+| Webhook HMAC signing secret | `Replicated_Webhook_Secret__mdt` | `Secret__c` | Text(255) | Protected | Not yet implemented (planned for `ReplicatedWebhookReceiver` HMAC-SHA256 verification) |
+
+Both CMTs were changed from Public to Protected visibility in PR #15. The underlying values remain unencrypted plaintext.
+
+## Options Evaluated
+
+### Option 1: Named Credentials (External Credential + Named Credential)
+
+Named Credentials are the Salesforce-standard mechanism for storing credentials used in outbound HTTP callouts. The modern architecture (API 56.0+) separates the endpoint URL (Named Credential) from the authentication mechanism (External Credential).
+
+**How it works for the API token:**
+
+1. An External Credential defines the `Custom` authentication protocol with a custom `Authorization` header using the merge field `{!$Credential.Replicated_Vendor_Portal.ApiToken}`
+2. A Named Credential stores the endpoint URL (`https://api.replicated.com`) and references the External Credential
+3. A Principal under the External Credential holds the encrypted token value
+4. Access is gated by Permission Sets (External Credential Principal Access)
+5. Apex code uses `callout:Replicated_API/vendor/v3/path` instead of hardcoded URLs and manual headers
+
+**Security properties:**
+
+| Property | Behavior |
+|---|---|
+| Encryption at rest | Yes. Values are write-only — never retrievable via SOQL, API, UI, or debug logs |
+| Visible in code/logs | No. Injected server-side at runtime |
+| Sandbox isolation | Secrets do NOT propagate on sandbox refresh |
+| Access control | Permission Set-gated per Principal |
+| Audit trail | Setup Audit Trail logs credential changes; Event Monitoring captures usage |
+| Separation of duties | Admin configures credential; developer references by name |
+| Version control exposure | Secrets never appear in metadata files — only the structure deploys |
+| Token rotation | Update via Setup UI or Connect REST API. Zero code changes |
+
+**Applicability:**
+- API token (outbound callout auth): **Direct fit.** This is the primary use case for Named Credentials.
+- HMAC webhook secret (inbound signature verification): **Not applicable.** Named Credentials are designed for outbound callout authentication, not for reading secrets in arbitrary Apex logic.
+
+**Developer Edition compatibility:** Named Credentials are a core platform feature available in all editions that support Apex callouts, including Developer Edition. The org already makes HTTP callouts via the existing Remote Site Setting.
+
+**Implementation impact:**
+- Create `ExternalCredential` and `NamedCredential` metadata (deployable via SFDX)
+- Populate the token value post-deployment via Setup UI or Connect REST API (secrets are excluded from metadata by design)
+- Refactor `ReplicatedPlatform.cls`: replace hardcoded endpoints with `callout:Replicated_API/path`, remove manual `Authorization` header, remove constructor dependency on `ReplicatedVendorPortalCredential__mdt`
+- Refactor `ReplicatedFulfillment.cls`: remove SOQL query for credential CMT
+- Remove `Replicated_Vendor_Portal_API_Credential__mdt` and `ReplicatedVendorPortal.remoteSite-meta.xml`
+- Create Permission Set for External Credential Principal Access
+- Update `package.xml` to include `NamedCredential` and `ExternalCredential` types
+
+### Option 2: Protected Custom Settings (Hierarchy) with Shield Platform Encryption
+
+Custom Settings support Hierarchy-type settings that can store org-level values. With Shield Platform Encryption (a paid add-on), fields can be encrypted at rest.
+
+**Limitations:**
+- Shield Platform Encryption requires an additional Salesforce license — not available on Developer Edition
+- Custom Settings do not support `EncryptedText` field types without Shield
+- Without Shield, a Protected Custom Setting offers the same security posture as a Protected CMT
+- Custom Settings are visible in Setup UI to users with View Setup and Configuration
+- Custom Settings values propagate to sandboxes on refresh
+
+**Applicability:** Not viable for the Developer Edition org. Would require Shield license ($X/user/month) for any meaningful security improvement over the current approach.
+
+### Option 3: Keep Current Protected Custom Metadata Types
+
+The current approach stores credentials in Protected CMTs with `DeveloperControlled` field manageability.
+
+**What Protected visibility provides:**
+- Not queryable via SOQL from subscriber org code (only same-namespace Apex)
+- Not visible in the Custom Metadata Types setup page to non-admin users
+- Values are controlled by the developer (require deployment to change)
+
+**What it does NOT provide:**
+- Encryption at rest (values are plaintext in the database)
+- Protection from admins with Customize Application permission (can read via SOQL in Execute Anonymous)
+- Sandbox isolation (values copy on refresh)
+- Separation of duties (anyone with org access who can write Apex can read the value)
+- Audit trail for credential access
+
+**Acceptability:** Reasonable for a non-production demo/development environment where the threat model is limited to accidental exposure rather than determined adversaries.
+
+## Recommendation
+
+### API Token → Named Credentials (Option 1)
+
+The API token should migrate to Named Credentials. This is the Salesforce-standard approach, provides genuine encryption and access control, works on Developer Edition, and simplifies the Apex code by eliminating manual credential management.
+
+The refactoring also removes the Remote Site Setting (Named Credentials automatically whitelist their endpoint) and eliminates the credential CMT entirely, reducing the metadata surface area.
+
+### HMAC Webhook Secret → Keep Protected CMT (Option 3)
+
+The webhook signing secret should remain in the Protected CMT. Named Credentials don't apply to inbound webhook verification, and Protected Custom Settings offer no security improvement without Shield. The Protected CMT with `DeveloperControlled` manageability is the most appropriate available mechanism for this use case on Developer Edition.
+
+**Documented risks for the HMAC secret:**
+- Readable by org admins via SOQL in Execute Anonymous
+- Not encrypted at rest without Shield Platform Encryption
+- Copies to sandboxes on refresh
+- Acceptable for demo/dev; would need Shield or a secrets management integration (e.g., AWS Secrets Manager via callout) for production
+
+## Implementation Guidance
+
+### Named Credential metadata structure
+
+```
+create-license/main/default/
+  externalCredentials/
+    Replicated_Vendor_Portal.externalCredential-meta.xml
+  namedCredentials/
+    Replicated_API.namedCredential-meta.xml
+```
+
+### ExternalCredential XML
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<ExternalCredential xmlns="http://soap.sforce.com/2006/04/metadata">
+    <label>Replicated Vendor Portal</label>
+    <authenticationProtocol>Custom</authenticationProtocol>
+    <externalCredentialParameters>
+        <parameterName>Authorization</parameterName>
+        <parameterType>HttpHeader</parameterType>
+        <parameterValue>{!$Credential.Replicated_Vendor_Portal.ApiToken}</parameterValue>
+    </externalCredentialParameters>
+    <principals>
+        <principalName>NamedPrincipal</principalName>
+        <principalType>NamedPrincipal</principalType>
+        <sequenceNumber>1</sequenceNumber>
+    </principals>
+</ExternalCredential>
+```
+
+### NamedCredential XML
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<NamedCredential xmlns="http://soap.sforce.com/2006/04/metadata">
+    <allowMergeFieldsInBody>false</allowMergeFieldsInBody>
+    <allowMergeFieldsInHeader>true</allowMergeFieldsInHeader>
+    <externalCredential>Replicated_Vendor_Portal</externalCredential>
+    <generateAuthorizationHeader>false</generateAuthorizationHeader>
+    <label>Replicated API</label>
+    <endpoint>https://api.replicated.com</endpoint>
+</NamedCredential>
+```
+
+### Apex refactoring pattern
+
+```apex
+// Before (ReplicatedPlatform.cls)
+public ReplicatedPlatform(ReplicatedVendorPortalCredential__mdt credential) {
+    this.apiToken = credential.ApiToken__c;
+}
+// ...
+req.setEndpoint('https://api.replicated.com/vendor/v3/customers/search');
+req.setHeader('Authorization', this.apiToken);
+
+// After
+public ReplicatedPlatform() {
+    // No credential needed — Named Credential handles auth
+}
+// ...
+req.setEndpoint('callout:Replicated_API/vendor/v3/customers/search');
+// Authorization header injected automatically
+```
+
+### Post-deployment: populate the token
+
+The Metadata API excludes secret values by design. After deploying the structure, set the token via:
+
+1. **Setup UI**: External Credential → Principal → edit Authentication Parameter
+2. **Connect REST API**: `POST /services/data/v61.0/named-credentials/external-credentials/Replicated_Vendor_Portal/principals/NamedPrincipal`
+
+### Makefile update
+
+The existing `make credentials` target should be updated to use the Connect REST API to populate the Named Credential principal instead of creating/updating the CMT record.
+
+## Security Trade-offs Summary
+
+| Concern | API Token (Named Credentials) | HMAC Secret (Protected CMT) |
+|---|---|---|
+| Encrypted at rest | Yes | No (requires Shield) |
+| Readable by admins | No (write-only) | Yes (SOQL in Execute Anonymous) |
+| Sandbox isolation | Yes (excluded from refresh) | No (copies on refresh) |
+| Audit trail | Yes (Setup Audit Trail) | No |
+| Code separation | Yes (developer never sees token) | No (Apex reads plaintext value) |
+| Token rotation | UI/API, no deployment | Requires metadata deployment |
+| Acceptable for production | Yes | Only with Shield or documented risk acceptance |
+
+## Related
+
+- [#21](https://github.com/crdant/replicated-salesforce-fulfillment/issues/21) — Evaluate secure secret storage for CMT credentials (this issue)
+- [#6](https://github.com/crdant/replicated-salesforce-fulfillment/issues/6) — Event-driven bidirectional sync (parent epic)
+- [PR #15](https://github.com/crdant/replicated-salesforce-fulfillment/pull/15) — Define Salesforce data model (changed CMTs to Protected)
+- [Salesforce Named Credentials Developer Guide](https://developer.salesforce.com/docs/platform/named-credentials/guide/get-started.html)
+- [Ross Belmont's API Key Named Credentials Guide](https://github.com/rossbelmont/named-creds-api-key)

--- a/docs/solutions/security-issues/secret-storage-evaluation-for-cmt-credentials.md
+++ b/docs/solutions/security-issues/secret-storage-evaluation-for-cmt-credentials.md
@@ -1,0 +1,124 @@
+---
+title: Secret storage evaluation for Custom Metadata Type credentials
+category: security-issues
+date: 2026-03-17
+tags:
+  - salesforce
+  - security
+  - secret-management
+  - custom-metadata-type
+  - named-credentials
+  - encryption
+components:
+  - Replicated_Vendor_Portal_API_Credential__mdt
+  - Replicated_Webhook_Secret__mdt
+  - ReplicatedPlatform
+  - ReplicatedFulfillment
+severity: high
+resolution_time: 1 session
+pr: 27
+issues: [21, 28]
+---
+
+# Secret Storage Evaluation for Custom Metadata Type Credentials
+
+Evaluated three approaches for securing credentials stored as plaintext Text fields in Protected Custom Metadata Types. Recommended Named Credentials for the API token and keeping the Protected CMT for the HMAC webhook secret, with documented trade-offs for each.
+
+## Problem
+
+Two Custom Metadata Types store sensitive credentials as plaintext:
+
+- `Replicated_Vendor_Portal_API_Credential__mdt.ApiToken__c` — Vendor Portal API token (Text, 100)
+- `Replicated_Webhook_Secret__mdt.Secret__c` — HMAC-SHA256 signing secret (Text, 255)
+
+PR #15 changed both to `Protected` visibility, limiting SOQL access to same-namespace Apex code. But Protected visibility does not provide encryption at rest, sandbox isolation, audit trails, or separation of duties. Admin users with Customize Application permission can still read the plaintext values via Execute Anonymous.
+
+## Root Cause
+
+Custom Metadata Types are designed for configuration data, not secrets. Their visibility controls manage discoverability in the Setup UI but do not encrypt stored values or prevent programmatic access by privileged users. Salesforce CMTs do not support the `EncryptedText` field type.
+
+## Solution
+
+### API Token → Named Credentials
+
+Named Credentials (External Credential + Named Credential, API 56.0+) are the Salesforce-standard mechanism for outbound API authentication. The platform encrypts the credential at rest, injects it server-side at callout time, and never exposes the value via SOQL, API, UI, or debug logs.
+
+**Before** (plaintext CMT):
+```apex
+// ReplicatedFulfillment.cls
+ReplicatedVendorPortalCredential__mdt cred = [
+    SELECT ApiToken__c
+    FROM ReplicatedVendorPortalCredential__mdt
+    WHERE DeveloperName = 'Default'
+    LIMIT 1
+];
+this.platform = new ReplicatedPlatform(cred);
+
+// ReplicatedPlatform.cls
+req.setEndpoint('https://api.replicated.com/vendor/v3/customers/search');
+req.setHeader('Authorization', this.apiToken);
+```
+
+**After** (Named Credential):
+```apex
+// ReplicatedFulfillment.cls — no credential query needed
+this.platform = new ReplicatedPlatform();
+
+// ReplicatedPlatform.cls
+req.setEndpoint('callout:Replicated_API/vendor/v3/customers/search');
+// Authorization header injected automatically by the platform
+```
+
+The migration also eliminates the Remote Site Setting (`ReplicatedVendorPortal.remoteSite-meta.xml`) since Named Credentials automatically whitelist their endpoint.
+
+**Implementation deferred to issue #28.**
+
+### HMAC Webhook Secret → Keep Protected CMT
+
+Named Credentials only apply to outbound callout authentication. The HMAC signing secret is used for inbound webhook signature verification (`Crypto.generateMac('HmacSHA256', ...)`) and has no Named Credential equivalent.
+
+Protected Custom Settings offer no security improvement over Protected CMTs without Shield Platform Encryption, which requires a paid add-on not available on the Developer Edition org.
+
+**Documented risks:**
+- Readable by org admins via SOQL in Execute Anonymous
+- Not encrypted at rest without Shield Platform Encryption
+- Copies to sandboxes on refresh
+- Acceptable for dev/demo environments; would need Shield or an external secrets manager for production
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| API token storage | Named Credentials | Salesforce-standard, encrypted, access-controlled, audited, works on Developer Edition |
+| HMAC secret storage | Protected CMT (status quo) | Named Credentials not applicable to inbound use; no better platform option without Shield |
+| Implementation scope | Document now, implement later | Evaluation branch (`docs/`); implementation deferred to #28 |
+
+## Prevention
+
+### Credential Storage Decision Checklist
+
+- [ ] **Outbound API authentication?** Use Named Credentials — never store tokens in CMTs, Custom Settings, or Apex constants
+- [ ] **Inbound webhook secret?** Use Protected CMT with `DeveloperControlled` manageability; document the risk acceptance
+- [ ] **Public configuration?** (endpoints, app IDs) Regular CMT or Custom Setting — plaintext is acceptable
+- [ ] **Can the secret be rotated?** Named Credentials support UI/API rotation with zero code changes; CMTs require metadata deployment
+- [ ] **Is the credential in version control?** Named Credential secrets are excluded from metadata by design; CMT values appear in source
+
+### Anti-Patterns
+
+| Anti-Pattern | Why It Fails | Fix |
+|---|---|---|
+| API tokens in CMT Text fields | Plaintext, SOQL-readable, copies to sandboxes | Named Credentials |
+| Secrets in Apex constants | Compiled into org, visible in git history | Runtime retrieval from Named Credentials or Protected CMT |
+| Mixing config and secrets in one CMT | One leaked record exposes everything | Separate objects by sensitivity level |
+| No rotation schedule for rotatable secrets | Leaked token = indefinite access | Document rotation frequency; Named Credentials simplify rotation |
+| Committing credential values to git | Persists in history even after deletion | `.gitignore` credential files; Named Credentials exclude secrets from metadata |
+
+## Related
+
+- [PR #27](https://github.com/crdant/replicated-salesforce-fulfillment/pull/27) — Evaluation document PR
+- [#21](https://github.com/crdant/replicated-salesforce-fulfillment/issues/21) — Evaluate secure secret storage (this evaluation)
+- [#28](https://github.com/crdant/replicated-salesforce-fulfillment/issues/28) — Implement Named Credentials migration (follow-up)
+- [#6](https://github.com/crdant/replicated-salesforce-fulfillment/issues/6) — Event-driven bidirectional sync (parent epic)
+- [PR #15](https://github.com/crdant/replicated-salesforce-fulfillment/pull/15) — Changed CMTs to Protected visibility
+- [salesforce-data-model-review-hardening](../integration-issues/salesforce-data-model-review-hardening.md) — PR #15 code review findings (Fixes 7 & 8)
+- [2026-03-16-secret-storage-evaluation.md](../../research/2026-03-16-secret-storage-evaluation.md) — Full research document with implementation guidance


### PR DESCRIPTION
TL;DR
-----

Evaluates secure storage options for the two credentials currently in plaintext Custom Metadata Types and recommends a path forward for each.

Details
-------

Both `ReplicatedVendorPortalCredential__mdt` and `Replicated_Webhook_Secret__mdt` store sensitive values as plaintext Text fields. PR #15 changed them to Protected visibility, which limits SOQL access to same-namespace Apex, but that still leaves the values unencrypted and readable by admins.

Evaluated three options: Named Credentials, Protected Custom Settings with Shield Platform Encryption, and keeping the current Protected CMTs. Named Credentials are the clear winner for the API token — the platform encrypts the value at rest, injects the Authorization header at callout time, and never exposes the secret in SOQL, debug logs, or metadata exports. They also eliminate the Remote Site Setting since Named Credentials auto-whitelist their endpoint.

The HMAC webhook secret is a different story. Named Credentials only apply to outbound callout authentication, not inbound signature verification. Shield Platform Encryption would help but requires a paid add-on not available on Developer Edition. The Protected CMT is the best available option for this credential, with the risks documented.

The research document includes implementation guidance — metadata XML templates, the Apex refactoring pattern (`callout:Replicated_API/path` replacing hardcoded URLs and manual headers), and post-deployment steps for populating the token. Issue #28 tracks the actual migration.

Closes #21
Part of #6