### PR TITLE
Removes Account__c FLS from profiles

### DIFF
--- a/create-license/main/default/profiles/Admin.profile-meta.xml
+++ b/create-license/main/default/profiles/Admin.profile-meta.xml
@@ -55,11 +55,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>Replicated_Instance__c.Account__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>Replicated_Instance__c.App_Version__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/create-license/main/default/profiles/ContractManager.profile-meta.xml
+++ b/create-license/main/default/profiles/ContractManager.profile-meta.xml
@@ -55,11 +55,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>Replicated_Instance__c.Account__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>Replicated_Instance__c.App_Version__c</field>
         <readable>false</readable>
     </fieldPermissions>

--- a/create-license/main/default/profiles/Custom%3A Marketing Profile.profile-meta.xml
+++ b/create-license/main/default/profiles/Custom%3A Marketing Profile.profile-meta.xml
@@ -55,11 +55,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>Replicated_Instance__c.Account__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>Replicated_Instance__c.App_Version__c</field>
         <readable>false</readable>
     </fieldPermissions>

--- a/create-license/main/default/profiles/Custom%3A Sales Profile.profile-meta.xml
+++ b/create-license/main/default/profiles/Custom%3A Sales Profile.profile-meta.xml
@@ -55,11 +55,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>Replicated_Instance__c.Account__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>Replicated_Instance__c.App_Version__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/create-license/main/default/profiles/Custom%3A Support Profile.profile-meta.xml
+++ b/create-license/main/default/profiles/Custom%3A Support Profile.profile-meta.xml
@@ -55,11 +55,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>Replicated_Instance__c.Account__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>Replicated_Instance__c.App_Version__c</field>
         <readable>true</readable>
     </fieldPermissions>

--- a/create-license/main/default/profiles/MarketingProfile.profile-meta.xml
+++ b/create-license/main/default/profiles/MarketingProfile.profile-meta.xml
@@ -55,11 +55,6 @@
     </fieldPermissions>
     <fieldPermissions>
         <editable>false</editable>
-        <field>Replicated_Instance__c.Account__c</field>
-        <readable>true</readable>
-    </fieldPermissions>
-    <fieldPermissions>
-        <editable>false</editable>
         <field>Replicated_Instance__c.App_Version__c</field>
         <readable>false</readable>
     </fieldPermissions>


### PR DESCRIPTION
TL;DR
-----

Strips stale `Account__c` fieldPermissions entries from all 6 profile metadata files to fix a Salesforce deployment rejection caused by explicit FLS on a required field.

Details
--------

Salesforce enforces a metadata validation rule during deployment: profile XML files must not contain explicit `<fieldPermissions>` entries for fields marked `<required>true</required>`. When the Metadata API encounters these entries, it rejects the entire deployment with a validation error -- regardless of whether the field is a Lookup or a scalar type. The platform considers required-field visibility an intrinsic property managed at the object level, not something configurable per-profile.

`Replicated_Instance__c.Account__c` is a required Lookup to the Account object (`<required>true</required>`, `<type>Lookup</type>`). When PR #25 (commit `919a948`) added field-level security for all `Replicated_Instance__c` fields across 6 profiles, it included `Account__c` without checking whether the field was eligible for explicit FLS. The `Instance_Id__c` case of the same bug was caught and fixed in PR #36 (`a210af8`), but `Account__c` was missed because earlier documentation suggested required Lookups might be exempt from the restriction. They are not -- Salesforce applies the same rejection to all required fields regardless of type.

Verification audited all 7 required fields across the project's custom objects, Platform Events, and Custom Metadata Types. `Account__c` was the only remaining field with stale FLS entries. The other required custom object field (`Instance_Id__c`) was already cleaned up by PR #36. Platform Event fields (`ReplayId`, `Payload__c`) and Custom Metadata Type fields (`DeveloperName`, `MasterLabel`, `Language`, `Label`, `QualifiedApiName`) do not use profile-based FLS, so they are unaffected.

The change removes exactly 30 lines (5-line `<fieldPermissions>` blocks from each of 6 profiles) and adds nothing. No Apex code, schema definitions, or object metadata changes.

The pattern is documented in `docs/solutions/build-errors/salesforce-fls-required-field-deployment-rejection.md` from the `Instance_Id__c` fix, which includes a pre-deployment validation script to catch future occurrences.

## Test plan

- [ ] Run `make deploy` and confirm the deployment succeeds without FLS validation errors
- [ ] Verify `Account__c` field remains visible and functional on `Replicated_Instance__c` records in the org
- [ ] Run the pre-deployment validation script from `docs/solutions/build-errors/salesforce-fls-required-field-deployment-rejection.md` and confirm zero violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)