### PR TITLE
Codify PR description style rules

### DIFF
--- a/docs/solutions/workflow/pr-description-style-mismatch.md
+++ b/docs/solutions/workflow/pr-description-style-mismatch.md
@@ -64,6 +64,14 @@ Key characteristics extracted from PRs #1-5 (all by @crdant):
 - **No test plan section**
 - **No emoji or "Generated with Claude Code" footer**
 
+### Hard Rules
+
+These are non-negotiable, confirmed explicitly by the project owner:
+
+1. **Active voice throughout** — never passive ("was deployed", "is rejected")
+2. **Never refer to the changes/PR as an explicit subject** — no "The fix removes...", "The change updates...", "This PR adds...". Instead, state what happens directly: "Removes stale FLS entries..." or weave it into the narrative
+3. **First sentence of Details directly states what the code does** — lead with the action, not background context. Don't open with "Salesforce enforces a rule..." or "The CMT object was deployed as...". Open with what the code actually does, then explain why
+
 ## Solution
 
 Before writing PR descriptions:


### PR DESCRIPTION
TL;DR
-----

Adds three hard rules for PR description style to the existing learnings doc so future agents stop leading with context and stop referring to changes as subjects.

Details
-------

PRs #33-37 all opened their Details sections with background context ("Salesforce doesn't allow...", "Salesforce enforces a platform-level rule...") and referred to themselves in the third person ("The fix removes...", "The change updates..."). That drifted from the conversational, action-first style established in PRs #1-5.

Pinning down the three specific rules that distinguish good descriptions from the recent drift: always active voice, never make the PR itself the sentence subject, and open Details with what the code does. These go into the existing `pr-description-style-mismatch.md` learnings doc where agents already look for PR conventions.