### PR TITLE
Migrates project configuration and sample data to new Salesforce org

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -14,3 +14,6 @@ package.xml
 # ignore files supporting data import and cleanup
 hack/**
 data/**
+
+# don't redeploy everything a worktree
+.worktrees/**

--- a/data/Opportunity.json
+++ b/data/Opportunity.json
@@ -9,7 +9,7 @@
       "StageName": "Proposal/Price Quote",
       "Amount": 320000,
       "CloseDate": "2024-06-29",
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "AccountId": "@AccountRef2"
     },
     {
@@ -21,7 +21,7 @@
       "StageName": "Proposal/Price Quote",
       "Amount": 185000,
       "CloseDate": "2024-07-08",
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "AccountId": "@AccountRef6"
     },
     {
@@ -33,7 +33,7 @@
       "StageName": "Proposal/Price Quote",
       "Amount": 85000,
       "CloseDate": "2024-07-08",
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "AccountId": "@AccountRef19"
     },
     {
@@ -45,7 +45,7 @@
       "StageName": "Proposal/Price Quote",
       "Amount": 106000,
       "CloseDate": "2024-06-28",
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "AccountId": "@AccountRef20"
     }
   ]

--- a/data/PricebookEntry.json
+++ b/data/PricebookEntry.json
@@ -5,7 +5,7 @@
         "type": "PricebookEntry",
         "referenceId": "PricebookEntryRef1"
       },
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "Product2Id": "@Product2Ref1",
       "UnitPrice": 35000,
       "UseStandardPrice": false,
@@ -16,7 +16,7 @@
         "type": "PricebookEntry",
         "referenceId": "PricebookEntryRef2"
       },
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "Product2Id": "@Product2Ref2",
       "UnitPrice": 85000,
       "UseStandardPrice": false,
@@ -27,7 +27,7 @@
         "type": "PricebookEntry",
         "referenceId": "PricebookEntryRef4"
       },
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "Product2Id": "@Product2Ref4",
       "UnitPrice": 15,
       "UseStandardPrice": false,
@@ -38,7 +38,7 @@
         "type": "PricebookEntry",
         "referenceId": "PricebookEntryRef5"
       },
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "Product2Id": "@Product2Ref5",
       "UnitPrice": 100000,
       "UseStandardPrice": false,
@@ -49,7 +49,7 @@
         "type": "PricebookEntry",
         "referenceId": "PricebookEntryRef6"
       },
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "Product2Id": "@Product2Ref6",
       "UnitPrice": 50000,
       "UseStandardPrice": false,
@@ -60,7 +60,7 @@
         "type": "PricebookEntry",
         "referenceId": "PricebookEntryRef7"
       },
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "Product2Id": "@Product2Ref7",
       "UnitPrice": 50000,
       "UseStandardPrice": false,
@@ -71,7 +71,7 @@
         "type": "PricebookEntry",
         "referenceId": "PricebookEntryRef8"
       },
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "Product2Id": "@Product2Ref8",
       "UnitPrice": 85000,
       "UseStandardPrice": false,
@@ -82,7 +82,7 @@
         "type": "PricebookEntry",
         "referenceId": "PricebookEntryRef9"
       },
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "Product2Id": "@Product2Ref9",
       "UnitPrice": 125000,
       "UseStandardPrice": false,
@@ -93,7 +93,7 @@
         "type": "PricebookEntry",
         "referenceId": "PricebookEntryRef10"
       },
-      "Pricebook2Id": "01saj000004bZqwAAE",
+      "Pricebook2Id": "01sdL00000Ks6SQQAZ",
       "Product2Id": "@Product2Ref10",
       "UnitPrice": 100000,
       "UseStandardPrice": false,

--- a/data/Product2.json
+++ b/data/Product2.json
@@ -1,164 +1,164 @@
 {
-    "records": [
-        {
-            "attributes": {
-                "type": "Product2",
-                "referenceId": "Product2Ref1"
-            },
-            "Name": "Slackernews",
-            "IsActive": true,
-            "IsAddOn__c": false,
-            "IsAdminConsoleEnabled__c": false,
-            "IsAirgapEnabled__c": false,
-            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
-            "IsEmbeddedClusterEnabled__c": false,
-            "ReleaseChannel__c": "2Ukd6ZSK5i9We0m9WznyBI19RtM",
-            "IsSnapshotSupported__c": false,
-            "IsSupportBundleUploadEnabled__c": false
-        },
-        {
-            "attributes": {
-                "type": "Product2",
-                "referenceId": "Product2Ref2"
-            },
-            "Name": "Slackernews (LTS Edition)",
-            "IsActive": true,
-            "IsAddOn__c": false,
-            "IsAdminConsoleEnabled__c": true,
-            "IsAirgapEnabled__c": false,
-            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
-            "IsEmbeddedClusterEnabled__c": false,
-            "ReleaseChannel__c": "2fBjnuGTivP2DeQyDPRhuJPP8bS",
-            "IsSnapshotSupported__c": true,
-            "IsSupportBundleUploadEnabled__c": false
-        },
-        {
-            "attributes": {
-                "type": "Product2",
-                "referenceId": "Product2Ref3"
-            },
-            "Name": "Slackernews User Pack",
-            "IsActive": false,
-            "IsAddOn__c": false,
-            "IsAdminConsoleEnabled__c": false,
-            "IsAirgapEnabled__c": false,
-            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
-            "IsEmbeddedClusterEnabled__c": false,
-            "ReleaseChannel__c": "2Ukd6ZSK5i9We0m9WznyBI19RtM",
-            "IsSnapshotSupported__c": false,
-            "IsSupportBundleUploadEnabled__c": false
-        },
-        {
-            "attributes": {
-                "type": "Product2",
-                "referenceId": "Product2Ref4"
-            },
-            "Name": "Slackernews Users",
-            "IsActive": true,
-            "IsAddOn__c": true,
-            "IsAdminConsoleEnabled__c": false,
-            "IsAirgapEnabled__c": false,
-            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
-            "IsEmbeddedClusterEnabled__c": false,
-            "ReleaseChannel__c": "NOT REQUIRED",
-            "IsSnapshotSupported__c": false,
-            "IsSupportBundleUploadEnabled__c": false
-        },
-        {
-            "attributes": {
-                "type": "Product2",
-                "referenceId": "Product2Ref5"
-            },
-            "Name": "Slackernews (Kubernetes Appliance LTS Edition)",
-            "IsActive": true,
-            "IsAddOn__c": false,
-            "IsAdminConsoleEnabled__c": true,
-            "IsAirgapEnabled__c": false,
-            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
-            "IsEmbeddedClusterEnabled__c": true,
-            "ReleaseChannel__c": "2fBjnuGTivP2DeQyDPRhuJPP8bS",
-            "IsSnapshotSupported__c": true,
-            "IsSupportBundleUploadEnabled__c": false
-        },
-        {
-            "attributes": {
-                "type": "Product2",
-                "referenceId": "Product2Ref6"
-            },
-            "Name": "Slackernews (GUI Installer)",
-            "IsActive": true,
-            "IsAddOn__c": false,
-            "IsAdminConsoleEnabled__c": true,
-            "IsAirgapEnabled__c": false,
-            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
-            "IsEmbeddedClusterEnabled__c": false,
-            "ReleaseChannel__c": "2Ukd6ZSK5i9We0m9WznyBI19RtM",
-            "IsSnapshotSupported__c": true,
-            "IsSupportBundleUploadEnabled__c": false
-        },
-        {
-            "attributes": {
-                "type": "Product2",
-                "referenceId": "Product2Ref7"
-            },
-            "Name": "Slackernews (Kubernetes Appliance)",
-            "IsActive": true,
-            "IsAddOn__c": false,
-            "IsAdminConsoleEnabled__c": true,
-            "IsAirgapEnabled__c": false,
-            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
-            "IsEmbeddedClusterEnabled__c": true,
-            "ReleaseChannel__c": "2Ukd6ZSK5i9We0m9WznyBI19RtM",
-            "IsSnapshotSupported__c": true,
-            "IsSupportBundleUploadEnabled__c": false
-        },
-        {
-            "attributes": {
-                "type": "Product2",
-                "referenceId": "Product2Ref8"
-            },
-            "Name": "Slackernews (Airgap)",
-            "IsActive": true,
-            "IsAddOn__c": false,
-            "IsAdminConsoleEnabled__c": true,
-            "IsAirgapEnabled__c": true,
-            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
-            "IsEmbeddedClusterEnabled__c": true,
-            "ReleaseChannel__c": "2Ukd6ZSK5i9We0m9WznyBI19RtM",
-            "IsSnapshotSupported__c": true,
-            "IsSupportBundleUploadEnabled__c": false
-        },
-        {
-            "attributes": {
-                "type": "Product2",
-                "referenceId": "Product2Ref9"
-            },
-            "Name": "Slackernews (Airgap LTS Edition)",
-            "IsActive": true,
-            "IsAddOn__c": false,
-            "IsAdminConsoleEnabled__c": true,
-            "IsAirgapEnabled__c": true,
-            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
-            "IsEmbeddedClusterEnabled__c": true,
-            "ReleaseChannel__c": "2fBjnuGTivP2DeQyDPRhuJPP8bS",
-            "IsSnapshotSupported__c": true,
-            "IsSupportBundleUploadEnabled__c": false
-        },
-        {
-            "attributes": {
-                "type": "Product2",
-                "referenceId": "Product2Ref10"
-            },
-            "Name": "Slackernews (GUI Installer LTS Edition)",
-            "IsActive": true,
-            "IsAddOn__c": false,
-            "IsAdminConsoleEnabled__c": true,
-            "IsAirgapEnabled__c": false,
-            "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
-            "IsEmbeddedClusterEnabled__c": false,
-            "ReleaseChannel__c": "2fBjnuGTivP2DeQyDPRhuJPP8bS",
-            "IsSnapshotSupported__c": true,
-            "IsSupportBundleUploadEnabled__c": false
-        }
-    ]
+  "records": [
+    {
+      "attributes": {
+        "type": "Product2",
+        "referenceId": "Product2Ref1"
+      },
+      "Name": "Slackernews",
+      "IsActive": true,
+      "IsAddOn__c": false,
+      "IsAdminConsoleEnabled__c": false,
+      "IsAirgapEnabled__c": false,
+      "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+      "IsEmbeddedClusterEnabled__c": false,
+      "ReleaseChannel__c": "2Ukd6XBJE3LDqpQjFlvQuGVRSBy",
+      "IsSnapshotSupported__c": false,
+      "IsSupportBundleUploadEnabled__c": false
+    },
+    {
+      "attributes": {
+        "type": "Product2",
+        "referenceId": "Product2Ref2"
+      },
+      "Name": "Slackernews (LTS Edition)",
+      "IsActive": true,
+      "IsAddOn__c": false,
+      "IsAdminConsoleEnabled__c": true,
+      "IsAirgapEnabled__c": false,
+      "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+      "IsEmbeddedClusterEnabled__c": false,
+      "ReleaseChannel__c": "2Ukd6XBJE3LDqpQjFlvQuGVRSBy",
+      "IsSnapshotSupported__c": true,
+      "IsSupportBundleUploadEnabled__c": false
+    },
+    {
+      "attributes": {
+        "type": "Product2",
+        "referenceId": "Product2Ref3"
+      },
+      "Name": "Slackernews User Pack",
+      "IsActive": false,
+      "IsAddOn__c": false,
+      "IsAdminConsoleEnabled__c": false,
+      "IsAirgapEnabled__c": false,
+      "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+      "IsEmbeddedClusterEnabled__c": false,
+      "ReleaseChannel__c": "2Ukd6XBJE3LDqpQjFlvQuGVRSBy",
+      "IsSnapshotSupported__c": false,
+      "IsSupportBundleUploadEnabled__c": false
+    },
+    {
+      "attributes": {
+        "type": "Product2",
+        "referenceId": "Product2Ref4"
+      },
+      "Name": "Slackernews Users",
+      "IsActive": true,
+      "IsAddOn__c": true,
+      "IsAdminConsoleEnabled__c": false,
+      "IsAirgapEnabled__c": false,
+      "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+      "IsEmbeddedClusterEnabled__c": false,
+      "ReleaseChannel__c": "2Ukd6XBJE3LDqpQjFlvQuGVRSBy",
+      "IsSnapshotSupported__c": false,
+      "IsSupportBundleUploadEnabled__c": false
+    },
+    {
+      "attributes": {
+        "type": "Product2",
+        "referenceId": "Product2Ref5"
+      },
+      "Name": "Slackernews (Kubernetes Appliance LTS Edition)",
+      "IsActive": true,
+      "IsAddOn__c": false,
+      "IsAdminConsoleEnabled__c": true,
+      "IsAirgapEnabled__c": false,
+      "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+      "IsEmbeddedClusterEnabled__c": true,
+      "ReleaseChannel__c": "2Ukd6XBJE3LDqpQjFlvQuGVRSBy",
+      "IsSnapshotSupported__c": true,
+      "IsSupportBundleUploadEnabled__c": false
+    },
+    {
+      "attributes": {
+        "type": "Product2",
+        "referenceId": "Product2Ref6"
+      },
+      "Name": "Slackernews (GUI Installer)",
+      "IsActive": true,
+      "IsAddOn__c": false,
+      "IsAdminConsoleEnabled__c": true,
+      "IsAirgapEnabled__c": false,
+      "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+      "IsEmbeddedClusterEnabled__c": false,
+      "ReleaseChannel__c": "2Ukd6XBJE3LDqpQjFlvQuGVRSBy",
+      "IsSnapshotSupported__c": true,
+      "IsSupportBundleUploadEnabled__c": false
+    },
+    {
+      "attributes": {
+        "type": "Product2",
+        "referenceId": "Product2Ref7"
+      },
+      "Name": "Slackernews (Kubernetes Appliance)",
+      "IsActive": true,
+      "IsAddOn__c": false,
+      "IsAdminConsoleEnabled__c": true,
+      "IsAirgapEnabled__c": false,
+      "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+      "IsEmbeddedClusterEnabled__c": true,
+      "ReleaseChannel__c": "2Ukd6XBJE3LDqpQjFlvQuGVRSBy",
+      "IsSnapshotSupported__c": true,
+      "IsSupportBundleUploadEnabled__c": false
+    },
+    {
+      "attributes": {
+        "type": "Product2",
+        "referenceId": "Product2Ref8"
+      },
+      "Name": "Slackernews (Airgap)",
+      "IsActive": true,
+      "IsAddOn__c": false,
+      "IsAdminConsoleEnabled__c": true,
+      "IsAirgapEnabled__c": true,
+      "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+      "IsEmbeddedClusterEnabled__c": true,
+      "ReleaseChannel__c": "2Ukd6XBJE3LDqpQjFlvQuGVRSBy",
+      "IsSnapshotSupported__c": true,
+      "IsSupportBundleUploadEnabled__c": false
+    },
+    {
+      "attributes": {
+        "type": "Product2",
+        "referenceId": "Product2Ref9"
+      },
+      "Name": "Slackernews (Airgap LTS Edition)",
+      "IsActive": true,
+      "IsAddOn__c": false,
+      "IsAdminConsoleEnabled__c": true,
+      "IsAirgapEnabled__c": true,
+      "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+      "IsEmbeddedClusterEnabled__c": true,
+      "ReleaseChannel__c": "2Ukd6XBJE3LDqpQjFlvQuGVRSBy",
+      "IsSnapshotSupported__c": true,
+      "IsSupportBundleUploadEnabled__c": false
+    },
+    {
+      "attributes": {
+        "type": "Product2",
+        "referenceId": "Product2Ref10"
+      },
+      "Name": "Slackernews (GUI Installer LTS Edition)",
+      "IsActive": true,
+      "IsAddOn__c": false,
+      "IsAdminConsoleEnabled__c": true,
+      "IsAirgapEnabled__c": false,
+      "Application__c": "2Ukd6bgLamUYOegqsNOPfjpfQVC",
+      "IsEmbeddedClusterEnabled__c": false,
+      "ReleaseChannel__c": "2Ukd6XBJE3LDqpQjFlvQuGVRSBy",
+      "IsSnapshotSupported__c": true,
+      "IsSupportBundleUploadEnabled__c": false
+    }
+  ]
 }

--- a/hack/clean
+++ b/hack/clean
@@ -59,8 +59,14 @@ delete pricebookEntriesToDelete;
 List<Product2> productsToDelete = [SELECT Id FROM Product2];
 delete productsToDelete;
 
+List<Case> casesToDelete = [SELECT Id FROM Case];
+delete casesToDelete;
+
 List<Contact> contactsToDelete = [SELECT Id FROM Contact];
 delete contactsToDelete;
+
+List<Entitlement> entitlementsToDelete = [SELECT Id FROM Entitlement];
+delete entitlementsToDelete;
 
 List<Account> accountsToDelete = [SELECT Id FROM Account];
 delete accountsToDelete;

--- a/hack/import
+++ b/hack/import
@@ -51,10 +51,10 @@ app_id=$(echo "${metadata}" | jq -r .app_id)
 channel_id=$(echo "${metadata}" | jq -r .channel_id) 
 
 # customize the product
-jq --arg name $app_name --arg app_id $app_id --arg channel_id $channel_id '{ "records": [ ( (.records[]) | .Name = (.Name | gsub("\\$APPLICATION"; $name)) | .Application__c = $app_id | .ReleaseChannel__c = $channel_id ) ] }' ${DATA_DIR}/Product2.json # | sponge ${DATA_DIR}/Product2.json
+jq --arg name $app_name --arg app_id $app_id --arg channel_id $channel_id '{ "records": [ ( (.records[]) | .Name = (.Name | gsub("\\$APPLICATION"; $name)) | .Application__c = $app_id | .ReleaseChannel__c = $channel_id ) ] }' ${DATA_DIR}/Product2.json | sponge ${DATA_DIR}/Product2.json
 
 # customize the opportunities
 jq --arg name $app_name '{ "records": [ ( (.records[]) | .Name = (.Name | gsub("\\$APPLICATION"; $name))) ] }' ${DATA_DIR}/Opportunity.json | sponge ${DATA_DIR}/Opportunity.json
 
 # import the graph of objects
-sf data import beta tree --plan ${DATA_DIR}/demo-data-plan.json -o ${ORG_ALIAS}
+sf data import tree --plan ${DATA_DIR}/demo-data-plan.json -o ${ORG_ALIAS}

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -7,6 +7,6 @@
   ],
   "name": "replicated-salesforce-trigger",
   "namespace": "",
-  "sfdcLoginUrl": "https://shortriblabs-dev-ed.develop.my.salesforce.com",
+  "sfdcLoginUrl": "https://orgfarm-ce7df7752f-dev-ed.develop.my.salesforce.com",
   "sourceApiVersion": "61.0"
 }


### PR DESCRIPTION
Updates demo environment for a new Salesforce developmer organization

TL;DR
-----

Synchronizes test data with a new Salesforce organization by updating IDs and fixing data import process issues.

Details
--------

Ensures the demo data references valid objects in the target organization, preventing those frustrating "invalid reference" errors during imports. Working with Salesforce demo data requires constant adaptation as organizations change. Every new org brings its own set of unique identifiers - pricebook IDs, release channel IDs, and login URLs that must match exactly or imports fail silently. 

Also strengthens the development workflow by excluding Git worktrees from deployments and expanding the cleanup script to handle cases and entitlements. When switching between orgs or resetting demo data, these objects often create dependency conflicts that block clean imports. The cleanup script now removes them in the correct order, respecting Salesforce's object relationships.

The switch from beta to stable import commands reflects the maturation of Salesforce CLI tooling. Beta commands often change without warning, breaking automation scripts at the worst possible times. Using the stable command ensures consistent behavior across team members' environments and CI/CD pipelines.
